### PR TITLE
Updated the footer on mobile view

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -17,6 +17,7 @@
   --font-size-headline-tablet: 2.4rem;
   --font-size-headline-desktop: 2.4rem;
   --font-size-headline-l-screen: 2.8rem;
+  --font-size-caption-mobile: 1.2rem;
   --font-size-caption: 1.2rem;
 }
 * {

--- a/assets/css/queries.css
+++ b/assets/css/queries.css
@@ -42,6 +42,7 @@
     padding: 9.6rem 2rem;
   }
 }
+
 @media (max-width: 59em) {
   html {
     font-size: 50%;
@@ -143,6 +144,7 @@
     display: block;
   }
 }
+
 @media (max-width: 44em) {
   .wrapper-grid {
     grid-template-columns: repeat(2, 1fr);
@@ -161,14 +163,20 @@
     width: 100%;
   }
   .grid--footer {
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr 1fr;
   }
   .logo-col,
   .address-col {
     grid-column: span 5;
   }
+  .footer-heading {
+    margin-bottom: 2rem;
+  }
+  .copyright {
+    font-size: var(--font-size-caption-mobile);
+  }
   .nav-col {
-    grid-row: 1;
     grid-column: span 2;
     margin-bottom: 3.2rem;
   }
@@ -182,6 +190,21 @@
   }
   .gallery .box {
     flex-direction: column;
+  }
+  .logo-col {
+    order: 3;
+    text-align: center;
+  }
+  .address-col {
+    order: 2;
+  }
+  .social-links {
+    width: fit-content;
+    margin: 0 auto;
+  }
+
+  .nav-col {
+    order: 1;
   }
 }
 @media (max-width: 34em) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -520,6 +520,7 @@
   display: flex;
   flex-direction: column;
 }
+
 .footer-logo {
   display: block;
   margin-bottom: 3.2rem;


### PR DESCRIPTION
-The grid is rearranged using order property. -The logo section in the footer is now centred with its texts. -The footer heading's padding is reduced from the existing 4rem to 2rem. - The task link is https://trello.com/c/0DgZZESJ/139-footer-on-mobile
![127 0 0 1_5501_index html (8)](https://github.com/georgebrata/tisamed-landing/assets/29037202/4615fcdd-1b56-4843-897a-f2d1152e3e2c)
